### PR TITLE
plugins/title: Provide option to blacklist urls

### DIFF
--- a/default_config.ini
+++ b/default_config.ini
@@ -30,3 +30,6 @@ help = grazyna.plugins.help
 
 [plugin:czy]
 file = conf_files/czy.txt
+
+[plugin:title]
+forum_ppcg = https://pl.python.org/forum/index.php

--- a/grazyna/plugins/title.py
+++ b/grazyna/plugins/title.py
@@ -113,8 +113,17 @@ def get_response(address, headers=None, redirect=True,
     return msg, resp
 
 
+def address_in_blacklist(address, blacklist):
+    for entry in blacklist:
+        if address.startswith(entry):
+            return True
+
+
 @asyncio.coroutine
 def check_title(bot, address, ssl):
+    if address_in_blacklist(address, bot.config.values()):
+        return
+
     msg, resp = yield from get_response(address, ssl=ssl)
 
     if resp is None:


### PR DESCRIPTION
As in subject.

With this you can skip checking title for any url starting with any option value set in plugin config. Option name can also work as additional comment.
